### PR TITLE
Automated trunk upgrade

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,23 +1,23 @@
 version: 0.1
 cli:
-  version: 1.22.6
+  version: 1.22.8
 lint:
   enabled:
-    - actionlint@1.7.3
+    - actionlint@1.7.5
     - git-diff-check@SYSTEM
-    - gitleaks@8.21.0
+    - gitleaks@8.22.1
     - gofmt@1.20.4
     - gokart@0.5.1
-    - golangci-lint@1.61.0
-    - markdownlint@0.42.0
-    - prettier@3.3.3
-    - renovate@38.124.3
+    - golangci-lint@1.62.2
+    - markdownlint@0.43.0
+    - prettier@3.4.2
+    - renovate@39.90.2
     - shellcheck@0.10.0
     - shfmt@3.6.0
     - terraform@1.8.5 # datasource=github-releases depName=hashicorp/terraform
-    - tflint@0.53.0
-    - tfsec@1.28.11
-    - trufflehog@3.82.9
+    - tflint@0.54.0
+    - tfsec@1.28.12
+    - trufflehog@3.88.0
     - yamllint@1.35.1
   disabled:
     - checkov
@@ -33,7 +33,7 @@ actions:
 plugins:
   sources:
     - id: trunk
-      ref: v1.6.4
+      ref: v1.6.6
       uri: https://github.com/trunk-io/plugins
 runtimes:
   enabled:


### PR DESCRIPTION


cli upgraded: 1.22.6 → 1.22.8

9 linters were upgraded:

- actionlint 1.7.3 → 1.7.5
- gitleaks 8.21.0 → 8.22.1
- golangci-lint 1.61.0 → 1.62.2
- markdownlint 0.42.0 → 0.43.0
- prettier 3.3.3 → 3.4.2
- renovate 38.124.3 → 39.90.2
- tflint 0.53.0 → 0.54.0
- tfsec 1.28.11 → 1.28.12
- trufflehog 3.82.9 → 3.88.0

1 plugin was upgraded:

- trunk-io/plugins v1.6.4 → v1.6.6

