### PR TITLE
Draft: Test ephemeral block

### DIFF
--- a/ephemeral.tf
+++ b/ephemeral.tf
@@ -1,0 +1,7 @@
+ephemeral "aws_kms_secrets" "secret" {
+  secret {
+    name    = "secret"
+    payload = "AQICAHhY4h6oV67xgokHQSgppqIoTXTPsMu3hBoLnmg4QWonqAGMzsK4nyoN+mee8rGu5Lm+AAAAZDBiBgkqhkiG9w0BBwagVTBTAgEAME4GCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQME6JCDiFXmgQ1KgRHAgEQgCGdTNbFT2fgotjzFi65w5TRmvP8zek9tZ9NFl61hGbUALg="
+    key_id  = "alias/default"
+  }
+}


### PR DESCRIPTION
Test for ephemeral block and how it is presented by Terraform Cloud.

I can be later added to demo.tf when Random provider will support ephemeral block too as I want to avoid using AWS provider.
