### PR TITLE
Better regexp for the output from TFE that misses ESC[0m and the beginning of the line

### DIFF
--- a/run/terraform_with_progress.go
+++ b/run/terraform_with_progress.go
@@ -104,7 +104,7 @@ func terraformWithProgress(command string, args []string) error {
 		`|read \(data resources\)` +
 		`|will be read during apply`
 
-	patternRefreshing := `(?:(?:\x1b\[0m)?\x1b\[1m)?(.*?): (Refresh)\w* st.*?(?:\r?\n|$)`
+	patternRefreshing := `(?:(?:\x1b\[0m)?\x1b\[1m)?(.*?): (Refresh).*(?:\r?\n|$)`
 	patternPreparingImport := `(?:(?:\x1b\[0m)?\x1b\[1m)?(.*?): (Prepar)\w* imp.*?(?:\r?\n|$)`
 	patternStartOperation := `(?:(?:\x1b\[0m)?\x1b\[1m)?(.*?): (Import|Read|Creat|Destr|Modif|Open|Clos)\w*ing.*?(?:\r?\n|$)`
 	patternStillOperation := `(?:(?:\x1b\[0m)?\x1b\[1m)?(.*?): Still (import|read|creat|destr|modif|open|clos).*?(?:\r?\n|$)`

--- a/run/terraform_with_progress.go
+++ b/run/terraform_with_progress.go
@@ -104,11 +104,11 @@ func terraformWithProgress(command string, args []string) error {
 		`|read \(data resources\)` +
 		`|will be read during apply`
 
-	patternRefreshing := `(?:.\[0m.\[1m)?(.*?): (Refresh)\w* st.*?(?:\r?\n|$)`
-	patternPreparingImport := `(?:.\[0m.\[1m)?(.*?): (Prepar)\w* imp.*?(?:\r?\n|$)`
-	patternStartOperation := `(?:.\[0m.\[1m)?(.*?): (Import|Read|Creat|Destr|Modif|Open|Clos)\w*ing.*?(?:\r?\n|$)`
-	patternStillOperation := `(?:.\[0m.\[1m)?(.*?): Still (import|read|creat|destr|modif|open|clos).*?(?:\r?\n|$)`
-	patternStopOperation := `(?:.\[0m.\[1m)?(.*?): (Import|Read|Creat|Destr|Modif|Open|Clos)\w* co.*?(?:\r?\n|$)`
+	patternRefreshing := `(?:(?:\x1b\[0m)?\x1b\[1m)?(.*?): (Refresh)\w* st.*?(?:\r?\n|$)`
+	patternPreparingImport := `(?:(?:\x1b\[0m)?\x1b\[1m)?(.*?): (Prepar)\w* imp.*?(?:\r?\n|$)`
+	patternStartOperation := `(?:(?:\x1b\[0m)?\x1b\[1m)?(.*?): (Import|Read|Creat|Destr|Modif|Open|Clos)\w*ing.*?(?:\r?\n|$)`
+	patternStillOperation := `(?:(?:\x1b\[0m)?\x1b\[1m)?(.*?): Still (import|read|creat|destr|modif|open|clos).*?(?:\r?\n|$)`
+	patternStopOperation := `(?:(?:\x1b\[0m)?\x1b\[1m)?(.*?): (Import|Read|Creat|Destr|Modif|Open|Clos)\w* co.*?(?:\r?\n|$)`
 
 	patternIgnoreOutputs := `^Outputs:(\n|$)`
 


### PR DESCRIPTION
The output from TFE misses `ESC[0m` and the beginning of line then it is not correctly parsed.
