### PR TITLE
Set buffer for scanner to 25MB

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,8 +2,6 @@ name: Test
 
 on:
   push:
-    branches:
-      - "**"
     paths-ignore:
       - .editorconfig
       - .gitignore

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,14 +1,6 @@
 name: Test
 
 on:
-  push:
-    paths-ignore:
-      - .editorconfig
-      - .gitignore
-      - .markdownlint.yaml
-      - .trunk/**
-      - LICENSE
-      - README.md
   pull_request:
     branches:
       - main

--- a/.github/workflows/trunk-check.yaml
+++ b/.github/workflows/trunk-check.yaml
@@ -1,9 +1,6 @@
 name: Trunk Check
 
 on:
-  push:
-    branches:
-      - "**"
   pull_request:
     branches:
       - main

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,3 +1,6 @@
+ignore: |
+  assets
+
 rules:
   quoted-strings:
     required: only-when-needed

--- a/run/terraform_with_filter.go
+++ b/run/terraform_with_filter.go
@@ -72,7 +72,8 @@ func terraformWithFilter(command string, args []string, patternIgnoreLine string
 	ignoreFooter := false
 	wasEmptyLine := false
 
-	reader := bufio.NewReader(cmdStdout)
+	// 25MB buffer
+	reader := bufio.NewReaderSize(cmdStdout, 25*1024*1024)
 
 	// buffer for the current line
 	line := ""

--- a/run/terraform_with_progress.go
+++ b/run/terraform_with_progress.go
@@ -226,7 +226,8 @@ func terraformWithProgress(command string, args []string) error {
 		return fmt.Errorf("starting the command: %w", err)
 	}
 
-	reader := bufio.NewReader(cmdStdout)
+	// 25MB buffer
+	reader := bufio.NewReaderSize(cmdStdout, 25*1024*1024)
 
 	isEof := false
 	ignoreNextLine := false

--- a/run/terraform_without_colors.go
+++ b/run/terraform_without_colors.go
@@ -34,6 +34,8 @@ func terraformWithoutColors(command string, noOutputs bool, args []string) error
 	skipOutputs := false
 
 	scanner := bufio.NewScanner(cmdStdout)
+	// 25MB max token size
+	scanner.Buffer(make([]byte, 0, 64*1024), 25*1024*1024)
 
 	for scanner.Scan() {
 		if skipOutputs {


### PR DESCRIPTION
This pull request increases the buffer size for reading output from Terraform commands in several functions, which helps handle larger outputs without running into buffer overflows or truncation issues.

**Buffer size increases for reading command output:**

* In `terraformWithFilter` (`run/terraform_with_filter.go`), the buffer size for `bufio.NewReader` is increased to 25MB to support larger outputs.
* In `terraformWithProgress` (`run/terraform_with_progress.go`), the buffer size for `bufio.NewReader` is also increased to 25MB.
* In `terraformWithoutColors` (`run/terraform_without_colors.go`), the maximum token size for `bufio.Scanner` is set to 25MB, allowing it to process much larger lines of output.