### PR TITLE
Automated go get update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,13 @@
 module github.com/dex4er/tf
 
-go 1.22
+go 1.24.0
 
 toolchain go1.25.1
 
 require (
 	github.com/awoodbeck/strftime v0.0.0-20180221155908-016cde65fcde
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db
-	golang.org/x/term v0.28.0
+	golang.org/x/term v0.35.0
 )
 
-require golang.org/x/sys v0.29.0 // indirect
+require golang.org/x/sys v0.36.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,7 @@ github.com/awoodbeck/strftime v0.0.0-20180221155908-016cde65fcde h1:1v6ARGjZnMYJ
 github.com/awoodbeck/strftime v0.0.0-20180221155908-016cde65fcde/go.mod h1:5nCO252N+QNZP3M986ViLdx44vRui5KuQkphwPHhYt8=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2EmQ4l5rM/4FEfDWcRD+abF5XlKShorW5LRoQ=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
-golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
-golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
-golang.org/x/term v0.28.0 h1:/Ts8HFuMR2E6IP/jlo7QVLZHggjKQbhu/7H0LJFr3Gg=
-golang.org/x/term v0.28.0/go.mod h1:Sw/lC2IAUZ92udQNf3WodGtn4k/XoLyZoh8v/8uiwek=
+golang.org/x/sys v0.36.0 h1:KVRy2GtZBrk1cBYA7MKu5bEZFxQk4NIDV6RLVcC8o0k=
+golang.org/x/sys v0.36.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/term v0.35.0 h1:bZBVKBudEyhRcajGcNc3jIfWPqV4y/Kt2XcoigOWtDQ=
+golang.org/x/term v0.35.0/go.mod h1:TPGtkTLesOwf2DE8CgVYiZinHAOuy5AYUYT1lENIZnA=


### PR DESCRIPTION
- downloading golang.org/x/term v0.35.0
- downloading golang.org/x/sys v0.36.0
- upgraded go 1.22 => 1.24.0
- upgraded golang.org/x/sys v0.29.0 => v0.36.0
- upgraded golang.org/x/term v0.28.0 => v0.35.0
