### PR TITLE
Automated go get update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.25.1
 require (
 	github.com/awoodbeck/strftime v0.0.0-20180221155908-016cde65fcde
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db
-	golang.org/x/term v0.35.0
+	golang.org/x/term v0.38.0
 )
 
-require golang.org/x/sys v0.36.0 // indirect
+require golang.org/x/sys v0.39.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,7 @@ github.com/awoodbeck/strftime v0.0.0-20180221155908-016cde65fcde h1:1v6ARGjZnMYJ
 github.com/awoodbeck/strftime v0.0.0-20180221155908-016cde65fcde/go.mod h1:5nCO252N+QNZP3M986ViLdx44vRui5KuQkphwPHhYt8=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2EmQ4l5rM/4FEfDWcRD+abF5XlKShorW5LRoQ=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
-golang.org/x/sys v0.36.0 h1:KVRy2GtZBrk1cBYA7MKu5bEZFxQk4NIDV6RLVcC8o0k=
-golang.org/x/sys v0.36.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
-golang.org/x/term v0.35.0 h1:bZBVKBudEyhRcajGcNc3jIfWPqV4y/Kt2XcoigOWtDQ=
-golang.org/x/term v0.35.0/go.mod h1:TPGtkTLesOwf2DE8CgVYiZinHAOuy5AYUYT1lENIZnA=
+golang.org/x/sys v0.39.0 h1:CvCKL8MeisomCi6qNZ+wbb0DN9E5AATixKsvNtMoMFk=
+golang.org/x/sys v0.39.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/term v0.38.0 h1:PQ5pkm/rLO6HnxFR7N2lJHOZX6Kez5Y1gDSJla6jo7Q=
+golang.org/x/term v0.38.0/go.mod h1:bSEAKrOT1W+VSu9TSCMtoGEOUcKxOKgl3LE5QEF/xVg=


### PR DESCRIPTION
- downloading golang.org/x/term v0.38.0
- downloading golang.org/x/sys v0.39.0
- upgraded golang.org/x/sys v0.36.0 => v0.39.0
- upgraded golang.org/x/term v0.35.0 => v0.38.0
