### PR TITLE
Automated trunk upgrade actionlint 1.7.7 → 1.7.12, gitleaks 8.28.0 → 8.30.1, golangci-lint 1.64.8 → 2.11.4, golangci-lint2 2.5.0 → 2.11.4, markdownlint 0.45.0 → 0.48.0, prettier 3.6.2 → 3.8.3, renovate 41.135.5 → 43.150.0, tflint 0.59.1 → 0.62.0, trufflehog 3.90.8 → 3.95.2, yamlfmt new → 0.21.0, yamllint 1.37.1 → 1.38.0, trunk-io/plugins v1.7.2 → v1.8.0, python 3.11.9 → 3.14.4 [skip ci]

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -3,22 +3,23 @@ cli:
   version: 1.25.0
 lint:
   enabled:
-    - golangci-lint2@2.5.0
-    - actionlint@1.7.7
+    - yamlfmt@0.21.0
+    - golangci-lint2@2.11.4
+    - actionlint@1.7.12
     - git-diff-check@SYSTEM
-    - gitleaks@8.28.0
+    - gitleaks@8.30.1
     - gofmt@1.20.4
-    - golangci-lint@1.64.8
-    - markdownlint@0.45.0
-    - prettier@3.6.2
-    - renovate@41.135.5
+    - golangci-lint@2.11.4
+    - markdownlint@0.48.0
+    - prettier@3.8.3
+    - renovate@43.150.0
     - shellcheck@0.11.0
     - shfmt@3.6.0
     - terraform@1.13.3 # datasource=github-releases depName=hashicorp/terraform
-    - tflint@0.59.1
+    - tflint@0.62.0
     - tfsec@1.28.14
-    - trufflehog@3.90.8
-    - yamllint@1.37.1
+    - trufflehog@3.95.2
+    - yamllint@1.38.0
   disabled:
     - checkov
     - gokart
@@ -35,10 +36,10 @@ actions:
 plugins:
   sources:
     - id: trunk
-      ref: v1.7.2
+      ref: v1.8.0
       uri: https://github.com/trunk-io/plugins
 runtimes:
   enabled:
     - go@1.26.2 # datasource=golang-version depName=go
     - node@22.16.0
-    - python@3.11.9
+    - python@3.14.4


### PR DESCRIPTION

11 linters were upgraded:

- actionlint 1.7.7 → 1.7.12
- gitleaks 8.28.0 → 8.30.1
- golangci-lint 1.64.8 → 2.11.4
- golangci-lint2 2.5.0 → 2.11.4
- markdownlint 0.45.0 → 0.48.0
- prettier 3.6.2 → 3.8.3
- renovate 41.135.5 → 43.150.0
- tflint 0.59.1 → 0.62.0
- trufflehog 3.90.8 → 3.95.2
- yamlfmt new → 0.21.0
- yamllint 1.37.1 → 1.38.0

1 plugin was upgraded:

- trunk-io/plugins v1.7.2 → v1.8.0

1 runtime was upgraded:

- python 3.11.9 → 3.14.4

