### PR TITLE
Automated trunk upgrade taplo new → 0.10.0 [skip ci]

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -3,7 +3,6 @@ cli:
   version: 1.25.0
 lint:
   enabled:
-    - taplo@0.10.0
     - actionlint@1.7.12
     - git-diff-check@SYSTEM
     - gitleaks@8.30.1
@@ -14,6 +13,7 @@ lint:
     - renovate@43.150.0
     - shellcheck@0.11.0
     - shfmt@3.6.0
+    - taplo@0.10.0
     - terraform@1.15.0 # datasource=github-releases depName=hashicorp/terraform
     - tflint@0.62.0
     - tfsec@1.28.14

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -3,6 +3,7 @@ cli:
   version: 1.25.0
 lint:
   enabled:
+    - taplo@0.10.0
     - actionlint@1.7.12
     - git-diff-check@SYSTEM
     - gitleaks@8.30.1


### PR DESCRIPTION

1 linter was upgraded:

- taplo new → 0.10.0

