### PR TITLE
Automated trunk upgrade golangci-lint2 2.11.4 → 2.12.2, tflint 0.62.0 → 0.62.1, trufflehog 3.95.2 → 3.95.3, trunk-io/plugins v1.8.0 → v1.10.0 [skip ci]

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -7,7 +7,7 @@ lint:
     - git-diff-check@SYSTEM
     - gitleaks@8.30.1
     - gofmt@1.20.4
-    - golangci-lint2@2.11.4
+    - golangci-lint2@2.12.2
     - markdownlint@0.48.0
     - prettier@3.8.3
     - renovate@43.150.0
@@ -15,9 +15,9 @@ lint:
     - shfmt@3.6.0
     - taplo@0.10.0
     - terraform@1.15.0 # datasource=github-releases depName=hashicorp/terraform
-    - tflint@0.62.0
+    - tflint@0.62.1
     - tfsec@1.28.14
-    - trufflehog@3.95.2
+    - trufflehog@3.95.3
     - yamlfmt@0.21.0
     - yamllint@1.38.0
   disabled:
@@ -36,7 +36,7 @@ actions:
 plugins:
   sources:
     - id: trunk
-      ref: v1.8.0
+      ref: v1.10.0
       uri: https://github.com/trunk-io/plugins
 runtimes:
   enabled:


### PR DESCRIPTION

3 linters were upgraded:

- golangci-lint2 2.11.4 → 2.12.2
- tflint 0.62.0 → 0.62.1
- trufflehog 3.95.2 → 3.95.3

1 plugin was upgraded:

- trunk-io/plugins v1.8.0 → v1.10.0

