### PR TITLE
Automated go get update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.26.3
 require (
 	github.com/awoodbeck/strftime v0.0.0-20180221155908-016cde65fcde
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db
-	golang.org/x/term v0.42.0
+	golang.org/x/term v0.43.0
 )
 
-require golang.org/x/sys v0.43.0 // indirect
+require golang.org/x/sys v0.44.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,7 @@ github.com/awoodbeck/strftime v0.0.0-20180221155908-016cde65fcde h1:1v6ARGjZnMYJ
 github.com/awoodbeck/strftime v0.0.0-20180221155908-016cde65fcde/go.mod h1:5nCO252N+QNZP3M986ViLdx44vRui5KuQkphwPHhYt8=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2EmQ4l5rM/4FEfDWcRD+abF5XlKShorW5LRoQ=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
-golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
-golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
-golang.org/x/term v0.42.0 h1:UiKe+zDFmJobeJ5ggPwOshJIVt6/Ft0rcfrXZDLWAWY=
-golang.org/x/term v0.42.0/go.mod h1:Dq/D+snpsbazcBG5+F9Q1n2rXV8Ma+71xEjTRufARgY=
+golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
+golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=
+golang.org/x/term v0.43.0/go.mod h1:lrhlHNdQJHO+1qVYiHfFKVuVioJIheAc3fBSMFYEIsk=


### PR DESCRIPTION
- downloading github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db
- downloading golang.org/x/term v0.42.0
- downloading github.com/awoodbeck/strftime v0.0.0-20180221155908-016cde65fcde
- downloading golang.org/x/term v0.43.0
- downloading golang.org/x/sys v0.43.0
- downloading golang.org/x/sys v0.44.0
- upgraded golang.org/x/sys v0.43.0 => v0.44.0
- upgraded golang.org/x/term v0.42.0 => v0.43.0
