### PR TITLE
Check if TF_IN_AUTOMATION is not empty, not just 1

### DIFF
--- a/run/terraform_with_progress.go
+++ b/run/terraform_with_progress.go
@@ -134,7 +134,7 @@ func terraformWithProgress(command string, args []string) error {
 	noColor := false
 	noOutputs := true
 
-	if TF_IN_AUTOMATION == "1" {
+	if TF_IN_AUTOMATION != "" {
 		progressFormat = progress.Verbose
 	}
 
@@ -390,7 +390,7 @@ func terraformWithProgress(command string, args []string) error {
 			}
 
 			// in CI do not add spaces clearing progress indicator
-			if TF_IN_AUTOMATION == "1" {
+			if TF_IN_AUTOMATION != "" {
 				fmt.Print(line)
 			} else {
 				console.Print(line)


### PR DESCRIPTION
This pull request updates the logic for detecting automation mode in the `terraformWithProgress` function. Instead of checking if `TF_IN_AUTOMATION` is exactly `"1"`, it now checks if the variable is set to any non-empty value, making the automation detection more flexible.
