### PR TITLE
Automated trunk upgrade markdownlint 0.48.0 → 0.49.0, prettier 3.8.3 → 3.8.4, renovate 43.150.0 → 43.236.0, tflint 0.62.1 → 0.63.1, trufflehog 3.95.3 → 3.95.6, trunk-io/plugins v1.10.0 → v1.10.2 [skip ci]

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -3,7 +3,6 @@ cli:
   version: 1.25.0
 lint:
   enabled:
-    - pinact@4.1.0
     - actionlint@1.7.12
     - git-diff-check@SYSTEM
     - gitleaks@8.30.1
@@ -26,6 +25,7 @@ lint:
     - gokart
     - grype
     - osv-scanner
+    - pinact
     - terrascan
     - trivy
 actions:

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -3,21 +3,22 @@ cli:
   version: 1.25.0
 lint:
   enabled:
+    - pinact@4.1.0
     - actionlint@1.7.12
     - git-diff-check@SYSTEM
     - gitleaks@8.30.1
     - gofmt@1.20.4
     - golangci-lint2@2.12.2
-    - markdownlint@0.48.0
-    - prettier@3.8.3
-    - renovate@43.150.0
+    - markdownlint@0.49.0
+    - prettier@3.8.4
+    - renovate@43.236.0
     - shellcheck@0.11.0
     - shfmt@3.6.0
     - taplo@0.10.0
     - terraform@1.15.0 # datasource=github-releases depName=hashicorp/terraform
-    - tflint@0.62.1
+    - tflint@0.63.1
     - tfsec@1.28.14
-    - trufflehog@3.95.3
+    - trufflehog@3.95.6
     - yamlfmt@0.21.0
     - yamllint@1.38.0
   disabled:
@@ -36,7 +37,7 @@ actions:
 plugins:
   sources:
     - id: trunk
-      ref: v1.10.0
+      ref: v1.10.2
       uri: https://github.com/trunk-io/plugins
 runtimes:
   enabled:


### PR DESCRIPTION

6 linters were upgraded:

- markdownlint 0.48.0 → 0.49.0
- prettier 3.8.3 → 3.8.4
- renovate 43.150.0 → 43.236.0
- tflint 0.62.1 → 0.63.1
- trufflehog 3.95.3 → 3.95.6

1 plugin was upgraded:

- trunk-io/plugins v1.10.0 → v1.10.2

