### PR TITLE
Changed format for tf -version to be more compatible

### DIFF
--- a/run/version.go
+++ b/run/version.go
@@ -3,7 +3,9 @@ package run
 import "fmt"
 
 func Version(args []string, version string) error {
-	fmt.Println("tf", "v"+version)
+	err := Terraform("version", args)
 
-	return Terraform("version", args)
+	fmt.Println("+ tf", "v"+version)
+
+	return err
 }

--- a/tests/01_version_terraform.out
+++ b/tests/01_version_terraform.out
@@ -1,4 +1,4 @@
 + ../../../tf version
-tf vX.X.X
 Terraform vX.X.X
 on XXX
++ tf vX.X.X

--- a/tests/02_version_tofu.out
+++ b/tests/02_version_tofu.out
@@ -1,4 +1,4 @@
 + ../../../tf version
-tf vX.X.X
 OpenTofu vX.X.X
 on XXX
++ tf vX.X.X

--- a/tests/03_arg_version_terraform.out
+++ b/tests/03_arg_version_terraform.out
@@ -1,4 +1,4 @@
 + ../../../tf -version
-tf vX.X.X
 Terraform vX.X.X
 on XXX
++ tf vX.X.X

--- a/tests/04_arg_version_tofu.out
+++ b/tests/04_arg_version_tofu.out
@@ -1,4 +1,4 @@
 + ../../../tf -version
-tf vX.X.X
 OpenTofu vX.X.X
 on XXX
++ tf vX.X.X


### PR DESCRIPTION
Presenting the tf version at the beginning breaks terragrunt and maybe even more tools.

Fixes #116 
