### PR TITLE
Migrate asdf -> mise

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,0 @@
-goreleaser 2.16.0 # datasource=github-releases depName=goreleaser/goreleaser
-opentofu   1.12.3 # datasource=github-releases depName=opentofu/opentofu

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,5 @@
+[tools]
+goreleaser = "2.16.0"
+
 [settings]
-idiomatic_version_file_enable_tools = ["go", "terraform"]
+idiomatic_version_file_enable_tools = ["go", "opentofu", "terraform"]


### PR DESCRIPTION
Dropped .tool-version

mise works with .opentofu-version directly and goreleaser goes to mise.toml.