### PR TITLE
Automated trunk upgrade markdownlint 0.49.0 → 0.49.1, prettier 3.8.4 → 3.9.6, tflint 0.63.1 → 0.64.0, trufflehog 3.95.6 → 3.95.9 [skip ci]

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -8,15 +8,15 @@ lint:
     - gitleaks@8.30.1
     - gofmt@1.20.4
     - golangci-lint2@2.12.2
-    - markdownlint@0.49.0
-    - prettier@3.8.4
+    - markdownlint@0.49.1
+    - prettier@3.9.6
     - shellcheck@0.11.0
     - shfmt@3.6.0
     - taplo@0.10.0
     - terraform@1.15.6 # datasource=github-releases depName=hashicorp/terraform
-    - tflint@0.63.1
+    - tflint@0.64.0
     - tfsec@1.28.14
-    - trufflehog@3.95.6
+    - trufflehog@3.95.9
     - yamlfmt@0.21.0
     - yamllint@1.38.0
   disabled:


### PR DESCRIPTION

4 linters were upgraded:

- markdownlint 0.49.0 → 0.49.1
- prettier 3.8.4 → 3.9.6
- tflint 0.63.1 → 0.64.0
- trufflehog 3.95.6 → 3.95.9

