### PR TITLE
Automated trunk upgrade trufflehog 3.95.9 → 3.96.0 [skip ci]

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -16,7 +16,7 @@ lint:
     - terraform@1.15.6 # datasource=github-releases depName=hashicorp/terraform
     - tflint@0.64.0
     - tfsec@1.28.14
-    - trufflehog@3.95.9
+    - trufflehog@3.96.0
     - yamlfmt@0.21.0
     - yamllint@1.38.0
   disabled:


### PR DESCRIPTION

1 linter was upgraded:

- trufflehog 3.95.9 → 3.96.0

