### PR TITLE
Automated trunk upgrade golangci-lint2 2.12.2 → 2.13.2, shfmt 3.6.0 → 3.14.1, trufflehog 3.96.0 → 3.97.4, trunk-io/plugins v1.10.2 → v1.11.0 [skip ci]

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -7,16 +7,16 @@ lint:
     - git-diff-check@SYSTEM
     - gitleaks@8.30.1
     - gofmt@1.20.4
-    - golangci-lint2@2.12.2
+    - golangci-lint2@2.13.2
     - markdownlint@0.49.1
     - prettier@3.9.6
     - shellcheck@0.11.0
-    - shfmt@3.6.0
+    - shfmt@3.14.1
     - taplo@0.10.0
     - terraform@1.15.8 # datasource=github-releases depName=hashicorp/terraform
     - tflint@0.64.0
     - tfsec@1.28.14
-    - trufflehog@3.96.0
+    - trufflehog@3.97.4
     - yamlfmt@0.21.0
     - yamllint@1.38.0
   disabled:
@@ -37,7 +37,7 @@ actions:
 plugins:
   sources:
     - id: trunk
-      ref: v1.10.2
+      ref: v1.11.0
       uri: https://github.com/trunk-io/plugins
 runtimes:
   enabled:


### PR DESCRIPTION

3 linters were upgraded:

- golangci-lint2 2.12.2 → 2.13.2
- shfmt 3.6.0 → 3.14.1
- trufflehog 3.96.0 → 3.97.4

1 plugin was upgraded:

- trunk-io/plugins v1.10.2 → v1.11.0

